### PR TITLE
remove the Number trait bound from CDatatype and `impl CDatatype for bool`

### DIFF
--- a/src/devices/cdatatype.rs
+++ b/src/devices/cdatatype.rs
@@ -1,8 +1,15 @@
-use crate::number::Number;
 
 /// enables easy generic kernel creation
-pub trait CDatatype: Number + 'static {
+pub trait CDatatype: 'static {
+    // TODO: this would make more sense as an associated constant
     fn as_c_type_str() -> &'static str;
+}
+
+impl CDatatype for bool {
+    #[inline]
+    fn as_c_type_str() -> &'static str {
+        "bool"
+    }
 }
 
 #[cfg(any(not(target_os = "macos"), not(feature = "opencl")))]

--- a/src/number.rs
+++ b/src/number.rs
@@ -4,10 +4,34 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign, RemAssign, Rem},
 };
 
-pub trait Number:
+pub trait Numeric:
     Sized
     + Default
     + Copy
+    + PartialOrd
+    + PartialEq
+    + core::fmt::Debug
+    + core::fmt::Display
+{}
+
+impl Numeric for bool {}
+impl Numeric for f32 {}
+impl Numeric for f64 {}
+impl Numeric for i8 {}
+impl Numeric for i16 {}
+impl Numeric for i32 {}
+impl Numeric for i64 {}
+impl Numeric for i128 {}
+impl Numeric for isize {}
+impl Numeric for u8 {}
+impl Numeric for u16 {}
+impl Numeric for u32 {}
+impl Numeric for u64 {}
+impl Numeric for u128 {}
+impl Numeric for usize {}
+
+pub trait Number:
+    Numeric
     + Add<Self, Output = Self>
     + Sub<Self, Output = Self>
     + Div<Self, Output = Self>
@@ -23,10 +47,6 @@ pub trait Number:
     + SubAssign<Self>
     + MulAssign<Self>
     + DivAssign<Self>
-    + PartialOrd
-    + PartialEq
-    + core::fmt::Debug
-    + core::fmt::Display
     + Sum<Self>
 {
     fn from_usize(value: usize) -> Self;


### PR DESCRIPTION
This is needed to prepare for supporting `Buffer<bool>` and `Matrix<bool>` as the result of a comparison